### PR TITLE
Update example-db.ddl

### DIFF
--- a/testing-persistence/scripts/example-db.ddl
+++ b/testing-persistence/scripts/example-db.ddl
@@ -53,7 +53,7 @@ CREATE TABLE Address (
     country VARCHAR(255)
 );
 
-CREATE TABLE Customer_AuctionSiteLogin (
+CREATE TABLE Customer_AuctionSiteCredentials (
     customer_id INTEGER NOT NULL, 
     auctionSiteLogins_id INTEGER NOT NULL,
    


### PR DESCRIPTION
Fixed table name for the database creation script to prevent a "java.sql.SQLException: Table/View 'CUSTOMER_AUCTIONSITECREDENTIALS' does not exis" on the persistability test.
